### PR TITLE
bot から AKA-AI を呼んで会話できるようにする (#21 Phase A)

### DIFF
--- a/ai/Dockerfile
+++ b/ai/Dockerfile
@@ -5,8 +5,11 @@ FROM node:22-alpine AS builder
 
 WORKDIR /workspace
 
-# pnpm を有効化（packageManager で固定したバージョンが使われる）
-RUN corepack enable
+# pnpm を有効化し、Cloud Build / ローカル両環境で同じ版を使う。
+# package.json の packageManager フィールドは使わない方針（pnpm 10/11
+# の自動切り替え機能が ENOENT を起こす環境があるため）なので、
+# corepack に明示的に pnpm 11.2.2 を activate する。
+RUN corepack enable && corepack prepare pnpm@11.2.2 --activate
 
 # monorepo の依存解決に必要な manifest をすべて先にコピー
 # bot 側もワークスペース定義に必要なため manifest だけ含める

--- a/bot/__tests__/aiClient.test.ts
+++ b/bot/__tests__/aiClient.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "./setup.js";
+import { TestConstants } from "./setup.js";
+import { chatWithAi } from "../src/aiClient.js";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("UrlFetchApp", { fetch: fetchMock });
+});
+
+function fakeResponse(status: number, body: unknown) {
+  return {
+    getResponseCode: () => status,
+    getContentText: () =>
+      typeof body === "string" ? body : JSON.stringify(body),
+  };
+}
+
+describe("chatWithAi", () => {
+  it("posts to <AI_BASE_URL>/chat/genai with base64-encoded key", () => {
+    fetchMock.mockReturnValue(fakeResponse(200, { reply: "あかだよ〜" }));
+
+    const result = chatWithAi("おはよう");
+
+    expect(result).toBe("あかだよ〜");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${TestConstants.AI_BASE_URL}/chat/genai`);
+    expect(options).toMatchObject({
+      method: "post",
+      contentType: "application/json; charset=UTF-8",
+      muteHttpExceptions: true,
+    });
+    const body = JSON.parse(options.payload as string);
+    expect(body.prompt).toBe("おはよう");
+    const expectedEncoded = Buffer.from(
+      TestConstants.GEMINI_API_KEY,
+      "utf-8",
+    ).toString("base64");
+    expect(body.encrypted_api_key).toBe(expectedEncoded);
+  });
+
+  it("returns null for empty prompt without calling fetch", () => {
+    const result = chatWithAi("   ");
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null on non-200 response", () => {
+    fetchMock.mockReturnValue(fakeResponse(502, { error: "genai_failed" }));
+    expect(chatWithAi("hi")).toBeNull();
+  });
+
+  it("returns null when reply is empty string", () => {
+    fetchMock.mockReturnValue(fakeResponse(200, { reply: "" }));
+    expect(chatWithAi("hi")).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    fetchMock.mockReturnValue(fakeResponse(200, "<<not json>>"));
+    expect(chatWithAi("hi")).toBeNull();
+  });
+
+  it("returns null on UrlFetchApp throw", () => {
+    fetchMock.mockImplementation(() => {
+      throw new Error("network down");
+    });
+    expect(chatWithAi("hi")).toBeNull();
+  });
+});

--- a/bot/__tests__/controller.test.ts
+++ b/bot/__tests__/controller.test.ts
@@ -2,12 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import "./setup.js";
 import { generateReply } from "../src/controller.js";
 
-vi.mock("../src/googleCalendarApi.js", () => ({
-  getEvents: vi.fn(() => ({ items: [] })),
-  getLunchEvents: vi.fn(() => []),
-  getDinnerEvents: vi.fn(() => []),
-}));
-
 describe("generateReply", () => {
   it("join event returns greeting", () => {
     const reply = generateReply({
@@ -18,40 +12,83 @@ describe("generateReply", () => {
     expect(reply).toContain("こんにちは、僕あか");
   });
 
-  it("exact match こんにちは responds to anyone", () => {
-    const reply = generateReply({
-      eventType: "message",
-      userMessage: "こんにちは",
-      isBotMentioned: false,
-    });
+  it("exact match こんにちは responds to anyone (no AI call)", () => {
+    const ai = vi.fn();
+    const reply = generateReply(
+      { eventType: "message", userMessage: "こんにちは", isBotMentioned: false },
+      { ai },
+    );
     expect(reply).toBe("こんにちは！ぼく、紅！");
+    expect(ai).not.toHaveBeenCalled();
   });
 
-  it("self introduction when mentioned", () => {
-    const reply = generateReply({
-      eventType: "message",
-      userMessage: "自己紹介して",
-      isBotMentioned: true,
-    });
+  it("self introduction when mentioned (no AI call)", () => {
+    const ai = vi.fn();
+    const reply = generateReply(
+      {
+        eventType: "message",
+        userMessage: "自己紹介して",
+        isBotMentioned: true,
+      },
+      { ai },
+    );
     expect(reply).toContain("こんにちは、僕あか");
+    expect(ai).not.toHaveBeenCalled();
   });
 
-  it("non-mentioned, non-exact-match → null", () => {
-    const reply = generateReply({
-      eventType: "message",
-      userMessage: "おはよう",
-      isBotMentioned: false,
-    });
+  it("non-mentioned, non-exact-match → null (no AI call)", () => {
+    const ai = vi.fn();
+    const reply = generateReply(
+      { eventType: "message", userMessage: "おはよう", isBotMentioned: false },
+      { ai },
+    );
     expect(reply).toBeNull();
+    expect(ai).not.toHaveBeenCalled();
   });
 
-  it("mentioned with random fallback returns non-empty string", () => {
-    const reply = generateReply({
-      eventType: "message",
-      userMessage: "何かしゃべって",
-      isBotMentioned: true,
-    });
-    expect(typeof reply).toBe("string");
-    expect((reply as string).length).toBeGreaterThan(0);
+  it("mentioned with free-form prompt → calls AI and returns its reply", () => {
+    const ai = vi.fn(() => "あかはね〜、今日も元気だよ〜！");
+    const fallback = vi.fn(() => "(should not be called)");
+    const reply = generateReply(
+      {
+        eventType: "message",
+        userMessage: "今何してたの？",
+        isBotMentioned: true,
+      },
+      { ai, fallback },
+    );
+    expect(ai).toHaveBeenCalledWith("今何してたの？");
+    expect(reply).toBe("あかはね〜、今日も元気だよ〜！");
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("AI failure → fallback is used", () => {
+    const ai = vi.fn(() => null);
+    const fallback = vi.fn(() => "random!");
+    const reply = generateReply(
+      {
+        eventType: "message",
+        userMessage: "なんか喋って",
+        isBotMentioned: true,
+      },
+      { ai, fallback },
+    );
+    expect(ai).toHaveBeenCalledOnce();
+    expect(fallback).toHaveBeenCalledOnce();
+    expect(reply).toBe("random!");
+  });
+
+  it("AI returns empty string → fallback is used", () => {
+    const ai = vi.fn(() => "");
+    const fallback = vi.fn(() => "random!");
+    const reply = generateReply(
+      {
+        eventType: "message",
+        userMessage: "なんか喋って",
+        isBotMentioned: true,
+      },
+      { ai, fallback },
+    );
+    expect(reply).toBe("random!");
   });
 });

--- a/bot/__tests__/setup.ts
+++ b/bot/__tests__/setup.ts
@@ -2,12 +2,14 @@ import { vi, beforeEach } from "vitest";
 
 const TEST_BOT_ID = "test-bot-id";
 const TEST_TOKEN = "test-token";
-const TEST_CALENDAR_ID = "primary";
+const TEST_AI_BASE_URL = "https://aka-ai.test.example.com";
+const TEST_GEMINI_API_KEY = "test-gemini-key";
 
 const propertyStore: Record<string, string | null> = {
   BOT_ID: TEST_BOT_ID,
   CHANNEL_ACCESS_TOKEN: TEST_TOKEN,
-  CALENDAR_ID: TEST_CALENDAR_ID,
+  AI_BASE_URL: TEST_AI_BASE_URL,
+  GEMINI_API_KEY: TEST_GEMINI_API_KEY,
 };
 
 export function setProperty(key: string, value: string | null): void {
@@ -18,7 +20,8 @@ export function resetProperties(): void {
   for (const key of Object.keys(propertyStore)) delete propertyStore[key];
   propertyStore.BOT_ID = TEST_BOT_ID;
   propertyStore.CHANNEL_ACCESS_TOKEN = TEST_TOKEN;
-  propertyStore.CALENDAR_ID = TEST_CALENDAR_ID;
+  propertyStore.AI_BASE_URL = TEST_AI_BASE_URL;
+  propertyStore.GEMINI_API_KEY = TEST_GEMINI_API_KEY;
 }
 
 vi.stubGlobal("PropertiesService", {
@@ -31,13 +34,15 @@ vi.stubGlobal("PropertiesService", {
 });
 
 vi.stubGlobal("UrlFetchApp", {
-  fetch: vi.fn(() => ({ getResponseCode: () => 200 })),
+  fetch: vi.fn(() => ({
+    getResponseCode: () => 200,
+    getContentText: () => "{}",
+  })),
 });
 
-vi.stubGlobal("Calendar", {
-  Events: {
-    list: vi.fn(() => ({ items: [] })),
-  },
+vi.stubGlobal("Utilities", {
+  base64Encode: (input: string) => Buffer.from(input, "utf-8").toString("base64"),
+  Charset: { UTF_8: "utf-8" },
 });
 
 beforeEach(() => {
@@ -47,4 +52,6 @@ beforeEach(() => {
 export const TestConstants = {
   BOT_ID: TEST_BOT_ID,
   TOKEN: TEST_TOKEN,
+  AI_BASE_URL: TEST_AI_BASE_URL,
+  GEMINI_API_KEY: TEST_GEMINI_API_KEY,
 };

--- a/bot/src/aiClient.ts
+++ b/bot/src/aiClient.ts
@@ -1,0 +1,57 @@
+import { getAiBaseUrl, getGeminiApiKey } from "./config.js";
+import type { components } from "./api/generated.js";
+
+type ChatRequest = components["schemas"]["ChatRequest"];
+type ChatResponse = components["schemas"]["ChatResponse"];
+
+/**
+ * AKA-AI の /chat/genai を叩いて応答テキストを取得する。
+ * - GAS の UrlFetchApp を使う（fetch は GAS にないため）
+ * - Script Properties から API キーを取得し base64 化してリクエストに含める
+ * - 失敗時は null を返す（呼び出し元でフォールバック）
+ */
+export function chatWithAi(prompt: string): string | null {
+  if (!prompt || prompt.trim().length === 0) return null;
+
+  const url = `${getAiBaseUrl().replace(/\/$/, "")}/chat/genai`;
+  const encryptedApiKey = Utilities.base64Encode(
+    getGeminiApiKey(),
+    Utilities.Charset.UTF_8,
+  );
+
+  const body: ChatRequest = {
+    prompt,
+    encrypted_api_key: encryptedApiKey,
+  };
+
+  let response: GoogleAppsScript.URL_Fetch.HTTPResponse;
+  try {
+    response = UrlFetchApp.fetch(url, {
+      method: "post",
+      contentType: "application/json; charset=UTF-8",
+      payload: JSON.stringify(body),
+      muteHttpExceptions: true,
+    });
+  } catch (err) {
+    console.error("aiClient: UrlFetchApp.fetch failed", err);
+    return null;
+  }
+
+  const status = response.getResponseCode();
+  const text = response.getContentText();
+  if (status !== 200) {
+    console.warn(
+      `aiClient: /chat/genai returned ${status} (body=${text.slice(0, 200)})`,
+    );
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as ChatResponse;
+    const reply = parsed.reply;
+    return typeof reply === "string" && reply.length > 0 ? reply : null;
+  } catch (err) {
+    console.error("aiClient: failed to parse response", err);
+    return null;
+  }
+}

--- a/bot/src/config.ts
+++ b/bot/src/config.ts
@@ -3,6 +3,8 @@
 
 const KEY_CHANNEL_ACCESS_TOKEN = "CHANNEL_ACCESS_TOKEN";
 const KEY_BOT_ID = "BOT_ID";
+const KEY_AI_BASE_URL = "AI_BASE_URL";
+const KEY_GEMINI_API_KEY = "GEMINI_API_KEY";
 
 function getProperty(key: string): string | null {
   return PropertiesService.getScriptProperties().getProperty(key);
@@ -22,4 +24,17 @@ export function getChannelAccessToken(): string {
 
 export function getBotId(): string {
   return getRequired(KEY_BOT_ID);
+}
+
+/**
+ * AKA-AI(Cloud Run) のベース URL。
+ * 例: https://aka-ai-api-service-225636122497.asia-northeast1.run.app
+ */
+export function getAiBaseUrl(): string {
+  return getRequired(KEY_AI_BASE_URL);
+}
+
+/** Gemini の生 API キー（base64 化前）。 */
+export function getGeminiApiKey(): string {
+  return getRequired(KEY_GEMINI_API_KEY);
 }

--- a/bot/src/controller.ts
+++ b/bot/src/controller.ts
@@ -1,4 +1,5 @@
 import * as AKA from "./aka.js";
+import { chatWithAi } from "./aiClient.js";
 
 export type EventType = "message" | "join" | string;
 
@@ -8,8 +9,18 @@ export interface GenerateReplyInput {
   isBotMentioned: boolean;
 }
 
+export interface GenerateReplyDeps {
+  /** AKA-AI を叩いて応答を取得する関数。テストで差し替え可能。 */
+  ai?: (prompt: string) => string | null;
+  /** AI 呼び出し失敗時のフォールバック。 */
+  fallback?: () => string;
+}
+
 /** 入力に対する応答テキストを生成する。応答すべきでないときは null。 */
-export function generateReply(input: GenerateReplyInput): string | null {
+export function generateReply(
+  input: GenerateReplyInput,
+  deps: GenerateReplyDeps = {},
+): string | null {
   if (input.eventType === "join") {
     return AKA.sayGreetings();
   }
@@ -28,8 +39,12 @@ export function generateReply(input: GenerateReplyInput): string | null {
   const selfIntro = generateSelfIntroductionReply(input.userMessage);
   if (selfIntro !== null) return selfIntro;
 
-  // フォールバック：ランダム（後で AKA-AI 呼び出しに置き換える予定 - #21）
-  return AKA.sayRandom();
+  // AI に投げる。失敗時はランダム応答にフォールバック
+  const ai = deps.ai ?? chatWithAi;
+  const fallback = deps.fallback ?? AKA.sayRandom;
+  const aiReply = ai(input.userMessage);
+  if (aiReply !== null && aiReply.length > 0) return aiReply;
+  return fallback();
 }
 
 /** メッセージが完全一致したときの応答。 */

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "22"
-pnpm = "10"
+pnpm = "11.2.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,12 @@ packages:
   - "bot"
   - "ai"
 
+# packageManager フィールドからの自動バージョン切り替えを無効化する。
+# ローカル (mise 経由の pnpm) と Cloud Build (corepack 経由) で
+# 個別にバージョンを管理し、pnpm が ~/Library/pnpm/.tools 配下に
+# ネイティブビルドを取りに行って失敗するのを防ぐ。
+manage-package-manager-versions: false
+
 allowBuilds:
   "@google/genai": true
   esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,6 @@ packages:
   - "bot"
   - "ai"
 
-# packageManager フィールドからの自動バージョン切り替えを無効化する。
-# ローカル (mise 経由の pnpm) と Cloud Build (corepack 経由) で
-# 個別にバージョンを管理し、pnpm が ~/Library/pnpm/.tools 配下に
-# ネイティブビルドを取りに行って失敗するのを防ぐ。
-manage-package-manager-versions: false
-
 allowBuilds:
   "@google/genai": true
   esbuild: true


### PR DESCRIPTION
## サマリ
bot 側からの応答を、テンプレ + ランダム応答止まりだった状態から、
メンション時に **AKA-AI (Cloud Run) を呼んで Gemini 応答を返す** 状態に進化させる。

これにより「あかとちゃんと会話できる Bot」の最低ライン（Phase A）を達成する。
会話履歴／コンテキスト管理（#21 の Phase B）は範囲外。別 PR で扱う。

refs #21

## 主な変更点

### `bot/src/config.ts`
- `AI_BASE_URL`（Cloud Run の URL）と `GEMINI_API_KEY` の Script Properties getter を追加

### `bot/src/aiClient.ts`（新規）
- `chatWithAi(prompt)` を提供
- `UrlFetchApp.fetch` で `<AI_BASE_URL>/chat/genai` に POST
- 生 API キーを `Utilities.base64Encode` で base64 化して送信
- OpenAPI 生成型 (`ChatRequest` / `ChatResponse`) を import して型を共通化
- 4xx/5xx / JSON 不正 / 例外時は `null` を返し、呼び出し元でフォールバック

### `bot/src/controller.ts`
- メンション時のフォールバックを `sayRandom()` から `chatWithAi()` に切り替え
- AI が `null` / 空文字を返したときは `sayRandom()` にフォールバック
- テスト容易性のため `ai` / `fallback` を deps として注入できるシグネチャに変更

### テスト
- `bot/__tests__/setup.ts`: `AI_BASE_URL` / `GEMINI_API_KEY` のスタブ、
  `Utilities.base64Encode` のスタブ、`UrlFetchApp` の `getContentText` 追加
- `bot/__tests__/aiClient.test.ts`（新規 / 6 ケース）: 正常系・空 prompt・5xx・空 reply・JSON 壊れ・fetch 例外
- `bot/__tests__/controller.test.ts`: AI 呼び出し経路を含む 7 ケースに拡充

### 応答ルーティング（変更後）
| 入力 | 応答 | AI 呼び出し |
|---|---|---|
| グループ参加 (join) | `sayGreetings()` | × |
| `こんにちは` 完全一致 | `sayHello()` | × |
| メンション + `自己紹介` を含む | `sayGreetings()` | × |
| メンションあり（その他） | **`chatWithAi(prompt)` の応答** | ○ |
| メンションあり + AI 失敗 | `sayRandom()` (フォールバック) | ○→ × |
| メンションなしのグループ（完全一致以外） | `null`（無視） | × |

## ローカル確認
- [x] `make typecheck` ✓
- [x] `pnpm --filter bot test`（18 件 pass）
- [x] `pnpm --filter ai test`（7 件 pass）
- [x] `pnpm --filter bot build` で `bot/dist/main.js` に `function doPost(e) { return _entry.doPost(e); }` が追記されていることを確認
- [x] `make oapi/check-gen` 差分なし

## マージ後にユーザー側で必要な作業

1. **新 GAS プロジェクトの Script Properties に 2 つ追加**
   - `AI_BASE_URL` = `https://aka-ai-api-service-225636122497.asia-northeast1.run.app`
   - `GEMINI_API_KEY` = AI Studio で取った生キー（base64 化なし）
2. `make deploy` で push（既に `bot/.clasp.json` は新 GAS プロジェクト）
3. 検証用 LINE チャネルで以下を確認
   - 個チャで雑談 → AI 応答が返る
   - グループで `@紅 こんにちは` → 完全一致テンプレ
   - グループで `あか、何してたの？` → AI 応答
   - グループ内のメンションなしメッセージ → 無反応
4. OK なら本番 LINE チャネルの Webhook URL を新 GAS プロジェクトに向け替え

## 次のステップ
- 会話履歴／コンテキスト管理（#21 Phase B、別 PR）
- グループメンション改善（#22）
- CI/CD（#20）