### PR TITLE
ci: Dependabot を導入する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  # ルート pnpm workspace の依存関係（bot / ai を含む）
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    # 細かい update が PR スパムにならないように関連 deps をまとめる
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+      types:
+        patterns:
+          - "@types/*"
+      hono:
+        patterns:
+          - "hono"
+          - "@hono/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+
+  # GitHub Actions の workflow で使うアクション
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## サマリ
`.github/dependabot.yml` を追加して、依存関係の自動更新 PR を毎週月曜
09:00 (Asia/Tokyo) に作るようにする。

## スコープ
- **npm**: ルート 1 つ。pnpm workspace 構成で `pnpm-lock.yaml` が
  ルートに 1 つだけある形のため、`bot/` `ai/` 別々に指定する必要なし
- **github-actions**: ワークフロー内の `actions/checkout` 等の更新も watch

## 抑制策
PR が増えすぎないよう、関連 deps は `groups` で 1 PR にまとめる：
- `typescript-eslint`: `@typescript-eslint/*`
- `types`: `@types/*`
- `hono`: `hono` と `@hono/*`
- `vitest`: `vitest` と `@vitest/*`

それ以外は個別 PR（最大 10 件まで）。

## ラベル / コミットメッセージ
- npm 更新: `dependencies` ラベル + `chore(deps)` プレフィックス
- actions 更新: `dependencies` + `ci` ラベル + `chore(ci)` プレフィックス

## 動作確認
- マージ後、リポジトリ Settings → Code security and analysis で
  Dependabot が enable されているか確認
- 初回 PR は monday 09:00 を待たずに、Insights → Dependency graph →
  Dependabot タブから「Check for updates」で手動トリガー可能