### PR TITLE
fix(ci): デプロイワークフローの初回失敗を修正

### DIFF
--- a/.github/workflows/bot-deploy.yml
+++ b/.github/workflows/bot-deploy.yml
@@ -37,14 +37,23 @@ jobs:
       - name: Build bot
         run: pnpm --filter bot build
 
+      # Secret を env 経由で渡すことで、shell 展開の段数を減らし、
+      # JSON 内の改行 / クォート / バックスラッシュで credentials が
+      # 壊れないようにする。直接 `printf "${{ secrets.X }}"` だと
+      # GitHub Actions の context 展開と bash の引数解析の二段で
+      # エスケープ事故が起きやすい。
       - name: Restore clasp credentials
+        env:
+          CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
-          mkdir -p ~/.config/google-clasp
-          printf '%s' "${{ secrets.CLASPRC_JSON }}" > ~/.clasprc.json
+          printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
           chmod 600 ~/.clasprc.json
+          # 復元できているか軽くサニティチェック（先頭バイトのみ表示）
+          test -s ~/.clasprc.json || { echo "::error::~/.clasprc.json is empty"; exit 1; }
+          head -c 1 ~/.clasprc.json | od -c | head -1
 
       - name: Verify clasp authentication
-        run: cd bot && pnpm clasp status
+        run: cd bot && pnpm clasp login --status
 
       - name: clasp push
         run: cd bot && pnpm clasp push --force

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,3 +16,7 @@ substitutions:
   _IMAGE_TAG: manual
 options:
   machineType: E2_HIGHCPU_8
+  # デフォルトの GCS ログバケットには SA が閲覧権限を持たず
+  # `gcloud builds submit` がログ stream 失敗で exit 1 する。
+  # Cloud Logging 専用にすることで GCS バケット権限を不要にする。
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## サマリ
ai-deploy と bot-deploy の初回手動実行で 2 つの根本的な問題が発生したので両方修正する。

## 1. ai-deploy: Cloud Build がログ stream に失敗して exit 1

### 症状
`gcloud builds submit` がイメージビルドの最中に：

```
ERROR: (gcloud.builds.submit)
The build is running, and logs are being written to the default logs bucket.
This tool can only stream logs if you are Viewer/Owner of the project and,
if applicable, allowed by your VPC-SC security policy.
```

を返して exit 1。

### 根本原因
Cloud Build はデフォルトで GCS の自動生成バケット (`gs://${PROJECT}_cloudbuildlogs`) にログを書く。`gcloud builds submit` はそのバケットからログを **tail** しようとするが、deploy 用 SA (`github-actions-deployer`) には GCS のバケット閲覧権限が無く、tail に失敗 → CLI が exit 1。

ビルド本体（Docker build + image push）は成功している可能性が高いが、Cloud Run のデプロイ step がスキップされてしまう。

### 対策
SA に GCS 権限を足すと攻撃面が広がるので、**Cloud Build 側でログ出力先を Cloud Logging のみに切り替える** のが正解。

`cloudbuild.yaml` の `options` に `logging: CLOUD_LOGGING_ONLY` を追加。これで GCS バケットへの書き込みが行われず、`gcloud builds submit` も Cloud Logging を tail する形になる。

## 2. bot-deploy: clasp push で「Could not read API credentials」

### 症状
`Verify clasp authentication` (= `clasp status`) は通っているが、`clasp push --force` で：

```
Could not read API credentials. Are you logged in globally?
```

を返して exit 1。

### 根本原因
`clasp status` は scriptId のファイル一覧表示のみで credentials を読まないが、`clasp push` は OAuth トークンを `~/.clasprc.json` から読む。CI でこのファイルが壊れている。

ファイルを書き込んでいた箇所:

```yaml
run: |
  printf '%s' "${{ secrets.CLASPRC_JSON }}" > ~/.clasprc.json
```

GitHub Actions の `${{ ... }}` context 展開 → bash の引数解析の **2 段の展開** を経由するため、Secret に含まれる改行 / クォート / バックスラッシュで JSON が壊れることがある（GitHub Actions 公式が `env:` 経由を推奨）。

### 対策
- Secret を `env:` で環境変数として 1 度だけ展開し、`printf '%s' "$CLASPRC_JSON"` で書き込む
- 復元直後にサニティチェック（空ファイル検出 + 先頭バイトの可視化）
- 動作確認の `clasp status` を、credentials の有無を明示的に確認する `clasp login --status` に変更

## ローカル確認
- [x] `make typecheck` ✓
- [x] `pnpm lint` ✓
- [x] `pnpm format` ✓

## マージ後の確認手順
1. Actions タブから **Deploy ai to Cloud Run** を再実行 → `/health` が 200 で返ることを確認
2. Actions タブから **Deploy bot to GAS** を再実行 → 検証用 LINE チャネルで挙動確認

## それでも bot-deploy が落ちる場合
`~/.clasprc.json` の中身が CI の clasp で読めない形式（例: clasp v3 で取得した credentials など）の可能性があります。その場合は手元で以下を確認:

```bash
# ローカルでも同じ clasp で credentials の状態を確認
pnpm --filter bot exec clasp login --status
```

これが「You are not logged in」と返れば、`pnpm --filter bot exec clasp login` で再ログインしてから新しい `~/.clasprc.json` の中身を GitHub Secret `CLASPRC_JSON` に貼り直してください。