### PR TITLE
fix(ci): Cloud Run deploy のロール不足 (artifactregistry.reader) を文書化

### DIFF
--- a/.github/workflows/ai-deploy.yml
+++ b/.github/workflows/ai-deploy.yml
@@ -1,5 +1,13 @@
 name: Deploy ai to Cloud Run
 
+# 必要な事前セットアップは docs/deploy-setup.md を参照。
+# デプロイ SA (github-actions-deployer) には以下のロールが必要:
+#   - roles/cloudbuild.builds.editor
+#   - roles/run.admin
+#   - roles/iam.serviceAccountUser
+#   - roles/storage.admin
+#   - roles/artifactregistry.reader  (Cloud Run deploy の pre-check で必須)
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/bot-deploy.yml
+++ b/.github/workflows/bot-deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy bot to GAS
 
+# 必要な事前セットアップ (clasp credentials / GitHub Secret CLASPRC_JSON)
+# は docs/deploy-setup.md を参照。
+
 on:
   workflow_dispatch:
     inputs:

--- a/docs/deploy-setup.md
+++ b/docs/deploy-setup.md
@@ -104,11 +104,11 @@ pbcopy < ~/.clasprc.json
 リポジトリの **Settings → Secrets and variables → Actions → New repository secret** で
 以下を登録する。
 
-| Secret 名 | 値 |
-|---|---|
-| `GCP_WIF_PROVIDER` | 上記 1.6) の出力 (`projects/<NUM>/locations/global/workloadIdentityPools/github-pool/providers/github-provider`) |
-| `GCP_SERVICE_ACCOUNT` | `github-actions-deployer@aka-ai-api.iam.gserviceaccount.com` |
-| `CLASPRC_JSON` | `~/.clasprc.json` の中身を改行込みで貼る |
+| Secret 名             | 値                                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `GCP_WIF_PROVIDER`    | 上記 1.6) の出力 (`projects/<NUM>/locations/global/workloadIdentityPools/github-pool/providers/github-provider`) |
+| `GCP_SERVICE_ACCOUNT` | `github-actions-deployer@aka-ai-api.iam.gserviceaccount.com`                                                     |
+| `CLASPRC_JSON`        | `~/.clasprc.json` の中身を改行込みで貼る                                                                         |
 
 確認:
 

--- a/docs/deploy-setup.md
+++ b/docs/deploy-setup.md
@@ -1,0 +1,142 @@
+# Deploy Setup
+
+`workflow_dispatch` で `Deploy ai to Cloud Run` / `Deploy bot to GAS`
+を回すために必要な GCP / GitHub 側の事前セットアップ手順をまとめる。
+**1 回だけ実行する作業**。
+
+---
+
+## 1. GCP: WIF + デプロイ用 Service Account
+
+```bash
+PROJECT_ID=aka-ai-api
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+SA_NAME=github-actions-deployer
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+POOL_ID=github-pool
+PROVIDER_ID=github-provider
+GITHUB_REPO=ktaroabobon/AKA
+
+# 1) Service Account を作成
+gcloud iam service-accounts create "$SA_NAME" \
+  --display-name="GitHub Actions deployer for AKA"
+
+# 2) SA にプロジェクトレベルのロールを付与
+#    artifactregistry.reader は gcr.io が Artifact Registry に
+#    バックエンド移行されているため Cloud Run deploy の pre-check で必須。
+for role in \
+  roles/cloudbuild.builds.editor \
+  roles/run.admin \
+  roles/iam.serviceAccountUser \
+  roles/storage.admin \
+  roles/artifactregistry.reader \
+; do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="$role"
+done
+
+# 3) Workload Identity Pool を作成
+gcloud iam workload-identity-pools create "$POOL_ID" \
+  --location=global --display-name="GitHub pool"
+
+# 4) GitHub OIDC プロバイダを作成（リポジトリ条件付き）
+gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_ID" \
+  --location=global --workload-identity-pool="$POOL_ID" \
+  --display-name="GitHub provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
+  --attribute-condition="assertion.repository == '${GITHUB_REPO}'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+# 5) GitHub からの impersonate を許可
+gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPO}"
+
+# 6) GitHub Actions に渡す値を出力
+echo "GCP_WIF_PROVIDER: projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+echo "GCP_SERVICE_ACCOUNT: ${SA_EMAIL}"
+```
+
+### すでに WIF をセットアップ済みで artifactregistry.reader だけ追加する場合
+
+```bash
+gcloud projects add-iam-policy-binding aka-ai-api \
+  --member="serviceAccount:github-actions-deployer@aka-ai-api.iam.gserviceaccount.com" \
+  --role="roles/artifactregistry.reader"
+```
+
+### SA に付与されているロールの確認
+
+```bash
+gcloud projects get-iam-policy aka-ai-api \
+  --flatten='bindings[].members' \
+  --filter='bindings.members:github-actions-deployer@aka-ai-api.iam.gserviceaccount.com' \
+  --format='value(bindings.role)'
+```
+
+期待する出力:
+
+```
+roles/artifactregistry.reader
+roles/cloudbuild.builds.editor
+roles/iam.serviceAccountUser
+roles/run.admin
+roles/storage.admin
+```
+
+---
+
+## 2. GAS: clasp credentials
+
+```bash
+# bot に紐づく Google アカウントで clasp login
+pnpm --filter bot exec clasp login
+
+# 認証情報の中身を Secret に登録するためコピー
+pbcopy < ~/.clasprc.json
+```
+
+---
+
+## 3. GitHub Secrets
+
+リポジトリの **Settings → Secrets and variables → Actions → New repository secret** で
+以下を登録する。
+
+| Secret 名 | 値 |
+|---|---|
+| `GCP_WIF_PROVIDER` | 上記 1.6) の出力 (`projects/<NUM>/locations/global/workloadIdentityPools/github-pool/providers/github-provider`) |
+| `GCP_SERVICE_ACCOUNT` | `github-actions-deployer@aka-ai-api.iam.gserviceaccount.com` |
+| `CLASPRC_JSON` | `~/.clasprc.json` の中身を改行込みで貼る |
+
+確認:
+
+```bash
+gh secret list
+# CLASPRC_JSON         ...
+# GCP_SERVICE_ACCOUNT  ...
+# GCP_WIF_PROVIDER     ...
+```
+
+---
+
+## 4. GitHub Environment 「production」（任意）
+
+Settings → Environments → New environment → `production`。
+
+- 個人プロジェクトでは特に protection rule を入れる必要なし
+- 厳しめに運用したい場合は `Deployment branches and tags` を `master` のみ
+  に限定する
+- 承認ゲートを置きたい場合は `Required reviewers` を有効化
+
+---
+
+## 5. デプロイの回し方
+
+GitHub の Actions タブから：
+
+- **Deploy ai to Cloud Run** → `workflow_dispatch` で実行（`ref` は通常 `master`）
+- **Deploy bot to GAS** → `workflow_dispatch` で実行
+
+任意の `ref`（ブランチ / タグ / SHA）を指定可能。


### PR DESCRIPTION
## サマリ
PR #31 で ai-deploy のログ問題は直ったが、次の段で別のエラーが出た。

```
ERROR: (gcloud.run.deploy) PERMISSION_DENIED:
Permission 'artifactregistry.repositories.downloadArtifacts'
denied on resource (or it may not exist).
```

## 根本原因
- `gcr.io` は **Artifact Registry にバックエンド移行**されており、
  `gcloud run deploy` の pre-check で対象イメージへの **read 権限**
  (`roles/artifactregistry.reader`) が要求される
- PR #29 で配布した WIF セットアップスクリプトに `artifactregistry.reader` が含まれていなかった
- 手動デプロイは Owner 個人で実行していたため気付かなかった

**ワークフロー自体に修正は不要**（SA 側に IAM admin 権限を持たせて self-grant は NG なので、ここでは直せない）。ユーザー側で 1 行追加実行する形になる。

## 変更点
- `docs/deploy-setup.md` を新設し、デプロイ用 GCP/GitHub 事前セットアップを全部 1 ファイルに集約
  - 必須ロール一覧に **`roles/artifactregistry.reader`** を追加
  - 既存ユーザー向けに「**1 ロールだけ追加するワンライナー**」を明記
- `.github/workflows/ai-deploy.yml` / `bot-deploy.yml` の冒頭コメントから `docs/deploy-setup.md` を参照させる

## マージ後にユーザーが必要なコマンド

すでに WIF セットアップ済みなので、artifactregistry.reader だけ追加で OK:

```bash
gcloud projects add-iam-policy-binding aka-ai-api \
  --member="serviceAccount:github-actions-deployer@aka-ai-api.iam.gserviceaccount.com" \
  --role="roles/artifactregistry.reader"
```

確認:

```bash
gcloud projects get-iam-policy aka-ai-api \
  --flatten='bindings[].members' \
  --filter='bindings.members:github-actions-deployer@aka-ai-api.iam.gserviceaccount.com' \
  --format='value(bindings.role)'
```

期待する出力:

```
roles/artifactregistry.reader
roles/cloudbuild.builds.editor
roles/iam.serviceAccountUser
roles/run.admin
roles/storage.admin
```

その後 Actions タブから **Deploy ai to Cloud Run** を再実行すれば、`/health` まで通るはずです。