### PR TITLE
fix(ai): Cloud Run 起動失敗を修正 — vendor 辞書を image に同梱

### DIFF
--- a/ai/Dockerfile
+++ b/ai/Dockerfile
@@ -22,6 +22,9 @@ RUN pnpm install --frozen-lockfile --filter ai...
 
 # ソースをコピーしてビルド（tsc → ai/dist）
 COPY ai/src ./ai/src
+# NG 辞書などの vendor 資産は dist にバンドルされないが、ランタイムで
+# `import.meta.url` 基準の readFileSync で参照されるため builder 経由で運ぶ。
+COPY ai/vendor ./ai/vendor
 RUN pnpm --filter ai build
 
 # 本番ランタイム用に prod 依存だけを独立ツリーとして取り出す。
@@ -40,6 +43,9 @@ WORKDIR /app
 COPY --from=builder /prod-out/package.json ./package.json
 COPY --from=builder /prod-out/node_modules ./node_modules
 COPY --from=builder /workspace/ai/dist ./dist
+# moderation.ts は `new URL("../../vendor/inappropriate-words-ja/...", import.meta.url)`
+# で NG 辞書を起動時に readFileSync する。dist と隣接させるため /app/vendor に置く。
+COPY --from=builder /workspace/ai/vendor ./vendor
 
 EXPOSE 8080
 USER node


### PR DESCRIPTION
## 概要

PR #47 マージ後の Deploy AKA workflow で Cloud Run の container が PORT 8080 で listen できずに起動失敗していた件の修正。

```
ERROR: (gcloud.run.deploy) The user-provided container failed to start and
listen on the port defined provided by the PORT=8080 environment variable
within the allocated timeout.
```

該当ジョブ: https://github.com/ktaroabobon/AKA/actions/runs/26326808659/job/77505981210

## 根本原因

`ai/src/services/moderation.ts` は **module top-level** で

```ts
const dictDir = new URL("../../vendor/inappropriate-words-ja/", import.meta.url);
readFileSync(new URL("Sexual.txt", dictDir), "utf-8");
readFileSync(new URL("Offensive.txt", dictDir), "utf-8");
```

のように NG 辞書を起動時に同期読込している。

ところが `ai/Dockerfile` の runner ステージは `ai/dist` / `package.json` / `node_modules` しかコピーしておらず、`ai/vendor/inappropriate-words-ja/` ディレクトリを image に同梱していなかった。

コンパイル後の JS パスは `/app/dist/services/moderation.js`、ここから `../../vendor/...` は `/app/vendor/...` に解決される。しかし `/app/vendor/` が image に存在しないため `readFileSync` が **ENOENT で throw** → Node プロセスが listen する前に exit → Cloud Run が「PORT で listen できない」と判定して revision を kill していた。

ローカル開発 (`make ai/dev`) は tsx で `ai/src/services/moderation.ts` から `../../vendor/...` を解決するので `ai/vendor/` が見つかり成功してしまっていた。production の dist 配置だけで顕在化する Dockerfile バグ。

## 修正内容

`ai/Dockerfile` を 2 段階で更新:

1. **builder ステージ**で `COPY ai/vendor ./ai/vendor` を追加 — ビルドコンテキストに辞書ファイル一式 (Sexual.txt / Offensive.txt / LICENSE / COMMIT) を持ち込む
2. **runner ステージ**で `COPY --from=builder /workspace/ai/vendor ./vendor` を追加 — image の `/app/vendor/inappropriate-words-ja/` に配置し、`/app/dist/...` から相対パス `../../vendor/...` が正しく解決されるようにする

## 確認手順

マージ後に GitHub Actions の **Deploy AKA** workflow を `workflow_dispatch` で再実行:

1. `bot` job が成功する
2. `ai` job の Cloud Build → Cloud Run deploy が成功する
3. `ai` job 末尾の `/health` smoke check (curl) が 200 を返す
4. `curl -X POST <service-url>/chat/genai` で実応答が返り、Cloud Logging に `piiRedactions` フィールド付きの構造化ログが出る

## 関連

- 不具合を導入した PR: #47 (`feat: conversation-context`)
- 関連 Issue: #21