### PR TITLE
fix(ci): runtime SA に Firestore role を付与 + デプロイ運用手順を更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ env:
   SERVICE_NAME: aka-ai-api-service
   IMAGE: asia.gcr.io/aka-ai-api/aka-ai-api-service-image
   GEMINI_MODEL: gemini-3.5-flash
+  # Cloud Run コンテナが ADC として使うランタイム SA。
+  # Firestore (`conversation` collection) への RW のため `roles/datastore.user`
+  # を付与してある必要がある。詳細は docs/deploy-setup.md。
+  RUNTIME_SA: aka-ai-api-sa@aka-ai-api.iam.gserviceaccount.com
 
 jobs:
   bot:
@@ -116,6 +120,7 @@ jobs:
           gcloud run deploy ${{ env.SERVICE_NAME }} \
             --image ${{ env.IMAGE }}:latest \
             --region ${{ env.GCP_REGION }} \
+            --service-account ${{ env.RUNTIME_SA }} \
             --allow-unauthenticated \
             --set-env-vars NODE_ENV=production,GEMINI_MODEL=${{ env.GEMINI_MODEL }},GCP_PROJECT_ID=${{ env.GCP_PROJECT_ID }}
 

--- a/docs/deploy-setup.md
+++ b/docs/deploy-setup.md
@@ -12,36 +12,60 @@
 
 ## 1. GCP: WIF + デプロイ用 Service Account
 
+AKA は 2 種類の SA を使い分ける。
+
+| SA                        | 役割                                                                                            | 必要ロール                                                                                                                                  |
+| ------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `github-actions-deployer` | GitHub Actions が WIF 経由で impersonate するデプロイ SA。Cloud Build / Cloud Run deploy を回す | `roles/cloudbuild.builds.editor`, `roles/run.admin`, `roles/iam.serviceAccountUser`, `roles/storage.admin`, `roles/artifactregistry.reader` |
+| `aka-ai-api-sa`           | Cloud Run の **ランタイム SA**。コンテナ実行時の ADC として Firestore / Gemini API に到達する   | `roles/datastore.user`                                                                                                                      |
+
+ランタイム SA に Firestore 権限が無いと `/chat/genai` が `SessionStoreError` で 500
+を返す ([fix #49](https://github.com/ktaroabobon/AKA/pull/49) の不具合事例)。
+**デプロイ SA に `roles/datastore.user` を付与しても効かない**点に注意。
+
 ```bash
 PROJECT_ID=aka-ai-api
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
 SA_NAME=github-actions-deployer
 SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+RUNTIME_SA_NAME=aka-ai-api-sa
+RUNTIME_SA_EMAIL="${RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 POOL_ID=github-pool
 PROVIDER_ID=github-provider
 GITHUB_REPO=ktaroabobon/AKA
 
-# 1) Service Account を作成
+# 1) デプロイ SA を作成
 gcloud iam service-accounts create "$SA_NAME" \
   --display-name="GitHub Actions deployer for AKA"
 
-# 2) SA にプロジェクトレベルのロールを付与
+# 2) デプロイ SA にプロジェクトレベルのロールを付与
 #    artifactregistry.reader は gcr.io が Artifact Registry に
 #    バックエンド移行されているため Cloud Run deploy の pre-check で必須。
-#    datastore.user は ai サービスが Firestore の conversation collection に
-#    読み書きするために必要 (Cloud Run の実行 SA に ADC 経由で付与される)。
 for role in \
   roles/cloudbuild.builds.editor \
   roles/run.admin \
   roles/iam.serviceAccountUser \
   roles/storage.admin \
   roles/artifactregistry.reader \
-  roles/datastore.user \
 ; do
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
     --member="serviceAccount:${SA_EMAIL}" \
     --role="$role"
 done
+
+# 2.5) ランタイム SA を作成し、Firestore アクセス権限を付与
+gcloud iam service-accounts create "$RUNTIME_SA_NAME" \
+  --display-name="AKA AI Cloud Run runtime"
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${RUNTIME_SA_EMAIL}" \
+  --role="roles/datastore.user"
+
+# デプロイ SA がランタイム SA を act-as できるようにする
+# (deploy.yml の `--service-account` 指定に必要)
+gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA_EMAIL" \
+  --role="roles/iam.serviceAccountUser" \
+  --member="serviceAccount:${SA_EMAIL}"
 
 # 3) Workload Identity Pool を作成
 gcloud iam workload-identity-pools create "$POOL_ID" \
@@ -73,32 +97,31 @@ gcloud projects add-iam-policy-binding aka-ai-api \
   --role="roles/artifactregistry.reader"
 ```
 
-### すでに WIF をセットアップ済みで datastore.user だけ追加する場合
+### すでにランタイム SA を作成済みで datastore.user だけ追加する場合
 
 ```bash
 gcloud projects add-iam-policy-binding aka-ai-api \
-  --member="serviceAccount:github-actions-deployer@aka-ai-api.iam.gserviceaccount.com" \
+  --member="serviceAccount:aka-ai-api-sa@aka-ai-api.iam.gserviceaccount.com" \
   --role="roles/datastore.user"
 ```
 
-### SA に付与されているロールの確認
+### 各 SA に付与されているロールの確認
 
 ```bash
+# デプロイ SA
 gcloud projects get-iam-policy aka-ai-api \
   --flatten='bindings[].members' \
   --filter='bindings.members:github-actions-deployer@aka-ai-api.iam.gserviceaccount.com' \
   --format='value(bindings.role)'
-```
+# → roles/artifactregistry.reader / cloudbuild.builds.editor /
+#   iam.serviceAccountUser / run.admin / storage.admin
 
-期待する出力:
-
-```
-roles/artifactregistry.reader
-roles/cloudbuild.builds.editor
-roles/datastore.user
-roles/iam.serviceAccountUser
-roles/run.admin
-roles/storage.admin
+# ランタイム SA
+gcloud projects get-iam-policy aka-ai-api \
+  --flatten='bindings[].members' \
+  --filter='bindings.members:aka-ai-api-sa@aka-ai-api.iam.gserviceaccount.com' \
+  --format='value(bindings.role)'
+# → roles/datastore.user
 ```
 
 ---

--- a/docs/deploy-setup.md
+++ b/docs/deploy-setup.md
@@ -261,3 +261,77 @@ gcloud run services update-traffic aka-ai-api-service \
 
 > rollback 後、失敗 revision の原因 (Cloud Run ログ / Firestore 権限 / env 変数等)
 > を別途調査・修正してから `Deploy AKA` を再実行する。
+
+### IAM 変更後に Cloud Run instance を強制リサイクル
+
+ランタイム SA に新しいロールを付与した直後は、**既存 instance が古い ADC
+トークンをキャッシュしたまま**生き残り、しばらくは古い権限で動くため
+`PERMISSION_DENIED` が混ざることがある (本 spec 構築時の実例: PR #50 以前)。
+Container image / env を変えずに instance だけ recycle するには、label 更新で
+新 revision を強制的に切る:
+
+```bash
+gcloud run services update aka-ai-api-service \
+  --region=asia-northeast1 \
+  --project=aka-ai-api \
+  --update-labels=force-restart=$(date +%s)
+```
+
+Cloud Run が新 revision を作って 100% traffic を切り替え、古い instance を
+kill する。無停止で完了。
+
+---
+
+## 7. bot 反映 — GAS の新バージョン発行と LINE Webhook 確認
+
+`jobs.bot` の `clasp push --force` は **スクリプトエディタにコードを書き込む**
+だけで、LINE Webhook が叩く Web App URL の **配信バージョンは自動で
+進まない**。新コードを本番に反映するには、GAS で「新しいバージョン」を
+明示的に発行する必要がある (同じ Web App URL のまま、内部バージョンだけ進める)。
+
+### 手順
+
+1. GAS エディタを開く
+   - リポルートで `make console` を実行するか、以下の URL を直接開く:
+     - https://script.google.com/home/projects/1Mmc00qLMFH5seUCLg-uYDP8OGX7eKTgMNxYG7nOcevrIqEGA2XqNfnIu/edit
+
+2. エディタ右上の **デプロイ** → **デプロイを管理** を開く
+
+3. LINE Webhook が使っている既存デプロイ (ウェブアプリ) の **編集** (鉛筆アイコン)
+   をクリック
+
+4. **バージョン** を「**新しいバージョン**」に切り替え、必要に応じ説明
+   (例: `feat: conversation-context`) を入力して **デプロイ**
+
+5. 表示される **ウェブアプリ URL** が変わっていないことを確認
+   (`https://script.google.com/macros/s/<deploymentId>/exec` の deploymentId
+   は維持される)
+
+> 同じ deployment を編集して新バージョンに切り替える限り URL は不変。
+> 「新規デプロイ」を押すと別 deploymentId の URL になってしまい、LINE 側の
+> Webhook 更新が必要になるので **既存デプロイの編集経路を使う**こと。
+
+### LINE Messaging API 側の確認
+
+LINE Developers Console:
+
+- https://developers.line.biz/console/channel/1660869337/messaging-api
+
+ここで **Webhook URL** が手順 5 の URL と一致していることを確認する。
+通常は何も触らなくてよい (deploymentId 不変のため)。URL を貼り直した場合は
+「検証」ボタンで疎通テストすると `Success` が返ることを確認する。
+
+### 動作確認 (smoke)
+
+LINE bot を経由した end-to-end チェック:
+
+1. LINE のグループ or 個チャで「あか」にメンションして任意のメッセージを送る
+2. 応答が返る (テンプレ即応 or AI 応答)
+3. (任意) Cloud Logging で `chat completed` イベントに該当ターンが流れて
+   いること、`piiRedactions` / `historyTurns` が記録されていることを確認
+4. (任意) Firestore Console で `conversation/user:{userId}` ドキュメントに
+   messages が追記されていることを確認
+
+> bot 経由でランダム応答が連発する場合は ai 側で 500 / 502 が返って
+> chatWithAi が null フォールバックしている。Cloud Logging で
+> `severity>=WARNING` のフィルタを掛けて根本原因を確認する。


### PR DESCRIPTION
## 概要

PR #47 / #49 マージ後、`/chat/genai` が 500 `internal_error` を返し続け、LINE bot からはランダム応答にフォールバックする不具合の修正と、その背景となる運用手順の整理。

実機での切り分けで以下を確認済み:

- ランタイム SA `aka-ai-api-sa` にプロジェクトロールが 1 つも付与されていなかった
- Firestore 呼び出しが `7 PERMISSION_DENIED` で弾かれ `SessionStoreError` → 500
- bot 側は設計どおり 500 を受けてランダム応答に落ちていた (= GAS 側の不具合ではない)
- `roles/datastore.user` 付与後も既存 instance が古い ADC token をキャッシュしていて間欠的に 500 が混じる → label 更新で Cloud Run revision を強制リサイクルして完全復旧

## 根本原因

`docs/deploy-setup.md` の旧記述では `roles/datastore.user` を **デプロイ SA** (`github-actions-deployer`) に付与する手順になっていたが、これは GitHub Actions が impersonate するデプロイ SA であって、Cloud Run コンテナが ADC として使うランタイム SA ではない。両者は別物。

実態として Cloud Run の runtime SA は `aka-ai-api-sa@aka-ai-api.iam.gserviceaccount.com` で、こちらにロールを付与しないと Firestore に到達できない。

## 修正内容

### `docs/deploy-setup.md`

- 冒頭の表で **デプロイ SA** と **ランタイム SA** の 2 種類があることを明示
- デプロイ SA のロール一覧から `roles/datastore.user` を削除
- ランタイム SA の作成 + `roles/datastore.user` 付与 + デプロイ SA から `iam.serviceAccountUser` 委譲の手順を追加
- 確認用 gcloud コマンドを 2 SA 分に分割
- **新 section 7「bot 反映 — GAS の新バージョン発行と LINE Webhook 確認」**: `clasp push --force` の後に GAS で「新しいバージョン」を発行しないと LINE Webhook に新コードが反映されない仕様をドキュメント化。同じ deploymentId を保つ手順 + LINE Developers Console での Webhook URL 確認 + LINE 経由の smoke check 手順を集約
- section 6 末尾に **「IAM 変更後に Cloud Run instance を強制リサイクル」** を追記。今回の事例どおりの label 更新で無停止 recycle するワンライナーを記載

### `.github/workflows/deploy.yml`

- `env.RUNTIME_SA` を追加し、`gcloud run deploy --service-account` で明示的にランタイム SA を指定する。将来 SA が漏れて default Compute SA に切り替わる事故を防ぐ。

## 残作業

このコミットは設定 / 手順整理のみ。実 GCP 側で必要な作業は **本セッションで実機適用済み** だが、もし new clone から再現する場合は以下を実行する:

```bash
gcloud projects add-iam-policy-binding aka-ai-api \
  --member="serviceAccount:aka-ai-api-sa@aka-ai-api.iam.gserviceaccount.com" \
  --role="roles/datastore.user"

gcloud run services update aka-ai-api-service \
  --region=asia-northeast1 \
  --project=aka-ai-api \
  --update-labels=force-restart=$(date +%s)
```

## 動作確認

- ローカル curl: `/chat/genai` で 200 + reply + Firestore に history 書込 ✓ (本セッションで確認済)
- LINE bot 経由: メンションで AI 応答が返る ✓ (本セッションで確認済)
- Cloud Logging: `chat completed` イベントに `piiRedactions` / `historyTurns` / `geminiDurationMs` 構造化フィールドが記録される ✓

## 関連

- 不具合の発端となった PR: #47, #49
- 関連 Issue: #21