### PR TITLE
[codex] feat(ai): Gemini 呼び出しメトリクスをログ出力

### DIFF
--- a/ai/__tests__/genai.test.ts
+++ b/ai/__tests__/genai.test.ts
@@ -57,6 +57,7 @@ import {
 import { akaSystemInstruction } from "../src/prompts/aka.js";
 import type { ConversationMessage } from "../src/services/session.js";
 import type { Env } from "../src/config/env.js";
+import type { Logger } from "../src/lib/logger.js";
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
@@ -68,6 +69,17 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     FIRESTORE_DATABASE_ID: "(default)",
     ...overrides,
   };
+}
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+  } as unknown as Logger;
 }
 
 // base64("test-api-key") = "dGVzdC1hcGkta2V5"
@@ -108,6 +120,30 @@ describe("GenaiService.generate", () => {
     expect(reply).toBe("あかはねー、元気だよ！");
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith({ message: "やっほー" });
+  });
+
+  it("正常応答を model / attempt / status / fallbackUsed / durationMs 付きで構造化ログに出す", async () => {
+    const { sendMessage } = await getMocks();
+    sendMessage.mockResolvedValueOnce({
+      text: "あかはねー、元気だよ！",
+      candidates: [{ finishReason: "STOP" }],
+    });
+    const logger = makeLogger();
+
+    const service = createGenaiService(makeEnv(), logger);
+    await service.generate(makeInput());
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gemini-test-model",
+        attempt: 1,
+        status: "success",
+        fallbackUsed: false,
+        durationMs: expect.any(Number),
+        finishReason: "STOP",
+      }),
+      "genai attempt completed",
+    );
   });
 
   it("chats.create に systemInstruction と safetySettings 4 カテゴリ (BLOCK_MEDIUM_AND_ABOVE) が渡される (Req 4.1, 4.2)", async () => {
@@ -232,5 +268,29 @@ describe("GenaiService.generate", () => {
     await expect(service.generate(makeInput())).rejects.toMatchObject({
       cause,
     });
+  });
+
+  it("Gemini 呼び出し失敗を statusCode 付きで構造化ログに出す", async () => {
+    const cause = { status: 503, message: "high demand" };
+    const { sendMessage } = await getMocks();
+    sendMessage.mockRejectedValueOnce(cause);
+    const logger = makeLogger();
+
+    const service = createGenaiService(makeEnv(), logger);
+
+    await expect(service.generate(makeInput())).rejects.toBeInstanceOf(
+      GenaiServiceError,
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gemini-test-model",
+        attempt: 1,
+        status: "error",
+        fallbackUsed: false,
+        durationMs: expect.any(Number),
+        upstreamStatusCode: 503,
+      }),
+      "genai attempt failed",
+    );
   });
 });

--- a/ai/src/app.ts
+++ b/ai/src/app.ts
@@ -10,7 +10,7 @@ import type { Env } from "./config/env.js";
 
 export function createApp(env: Env) {
   const logger = createLogger(env);
-  const genaiService = createGenaiService(env);
+  const genaiService = createGenaiService(env, logger);
   const sessionService = createSessionService(getFirestore());
 
   const app = new Hono();

--- a/ai/src/services/genai.ts
+++ b/ai/src/services/genai.ts
@@ -22,6 +22,7 @@ import {
 
 import type { Env } from "../config/env.js";
 import { ApiKeyDecodeError, decodeApiKey } from "../lib/decode.js";
+import type { Logger } from "../lib/logger.js";
 import { akaSystemInstruction } from "../prompts/aka.js";
 import type { ConversationMessage } from "./session.js";
 
@@ -68,15 +69,73 @@ function toContent(m: ConversationMessage): Content {
   return { role: m.role, parts: [{ text: m.text }] };
 }
 
-export function createGenaiService(env: Env): GenaiService {
+function getErrorStatusCode(cause: unknown): number | undefined {
+  if (cause === null || typeof cause !== "object") return undefined;
+  const record = cause as Record<string, unknown>;
+  if (typeof record.status === "number") return record.status;
+  if (typeof record.code === "number") return record.code;
+  const response = record.response;
+  if (response !== null && typeof response === "object") {
+    const responseRecord = response as Record<string, unknown>;
+    if (typeof responseRecord.status === "number") return responseRecord.status;
+  }
+  const error = record.error;
+  if (error !== null && typeof error === "object") {
+    const errorRecord = error as Record<string, unknown>;
+    if (typeof errorRecord.code === "number") return errorRecord.code;
+  }
+  return undefined;
+}
+
+function logAttempt(
+  logger: Logger | undefined,
+  input: {
+    model: string;
+    attempt: number;
+    status: "success" | "error" | "safety_blocked";
+    fallbackUsed: boolean;
+    durationMs: number;
+    upstreamStatusCode?: number;
+    finishReason?: string;
+  },
+) {
+  if (!logger) return;
+  const logPayload = {
+    model: input.model,
+    attempt: input.attempt,
+    status: input.status,
+    fallbackUsed: input.fallbackUsed,
+    durationMs: input.durationMs,
+    ...(input.upstreamStatusCode === undefined
+      ? {}
+      : { upstreamStatusCode: input.upstreamStatusCode }),
+    ...(input.finishReason === undefined
+      ? {}
+      : { finishReason: input.finishReason }),
+  };
+  const message =
+    input.status === "success"
+      ? "genai attempt completed"
+      : input.status === "safety_blocked"
+        ? "genai attempt safety blocked"
+        : "genai attempt failed";
+  if (input.status === "error") {
+    logger.warn(logPayload, message);
+  } else {
+    logger.info(logPayload, message);
+  }
+}
+
+export function createGenaiService(env: Env, logger?: Logger): GenaiService {
   return {
     async generate({ history, userText, encryptedApiKey }) {
       // ApiKeyDecodeError はそのまま投げる (route 層が 400 invalid_api_key として直接処理)
       const apiKey = decodeApiKey(encryptedApiKey);
       const ai = new GoogleGenAI({ apiKey });
+      const model = env.GEMINI_MODEL;
 
       const chat = ai.chats.create({
-        model: env.GEMINI_MODEL,
+        model,
         config: {
           systemInstruction: akaSystemInstruction,
           safetySettings: SAFETY_SETTINGS,
@@ -85,11 +144,20 @@ export function createGenaiService(env: Env): GenaiService {
       });
 
       let response;
+      const startedAt = Date.now();
       try {
         response = await chat.sendMessage({ message: userText });
       } catch (cause) {
         // ApiKeyDecodeError は decodeApiKey からのみ伝播する想定だが念のため
         if (cause instanceof ApiKeyDecodeError) throw cause;
+        logAttempt(logger, {
+          model,
+          attempt: 1,
+          status: "error",
+          fallbackUsed: false,
+          durationMs: Date.now() - startedAt,
+          upstreamStatusCode: getErrorStatusCode(cause),
+        });
         throw new GenaiServiceError("Failed to call Gemini", { cause });
       }
 
@@ -97,11 +165,27 @@ export function createGenaiService(env: Env): GenaiService {
       const candidates = response.candidates ?? [];
       const finishReason = candidates[0]?.finishReason;
       if (finishReason === FinishReason.SAFETY) {
+        logAttempt(logger, {
+          model,
+          attempt: 1,
+          status: "safety_blocked",
+          fallbackUsed: false,
+          durationMs: Date.now() - startedAt,
+          finishReason,
+        });
         throw new GenaiSafetyBlockedError(
           "Gemini blocked the response by safetySettings",
         );
       }
       if (candidates.length === 0) {
+        logAttempt(logger, {
+          model,
+          attempt: 1,
+          status: "safety_blocked",
+          fallbackUsed: false,
+          durationMs: Date.now() - startedAt,
+          finishReason,
+        });
         throw new GenaiSafetyBlockedError(
           "Gemini returned no candidates (treated as safety block)",
         );
@@ -109,10 +193,26 @@ export function createGenaiService(env: Env): GenaiService {
 
       const reply = response.text;
       if (!reply) {
+        logAttempt(logger, {
+          model,
+          attempt: 1,
+          status: "safety_blocked",
+          fallbackUsed: false,
+          durationMs: Date.now() - startedAt,
+          finishReason,
+        });
         throw new GenaiSafetyBlockedError(
           "Gemini returned an empty response (treated as safety block)",
         );
       }
+      logAttempt(logger, {
+        model,
+        attempt: 1,
+        status: "success",
+        fallbackUsed: false,
+        durationMs: Date.now() - startedAt,
+        finishReason,
+      });
       return reply;
     },
   };


### PR DESCRIPTION
## 概要
- Gemini 呼び出しごとに `model`, `attempt`, `status`, `fallbackUsed`, `durationMs`, `upstreamStatusCode` を構造化ログに出すようにしました。
- GenaiService に logger を注入し、Cloud Run ログから Gemini 呼び出し結果を追えるようにしました。
- prompt や API key はログに出しません。
- 正常応答時と上流 503 時のログ出力をテストで固定しました。

## 背景
今回の本番障害は Gemini 上流の一過性 503 が原因でした。呼び出し単位の構造化ログがあると、アプリ側の障害かモデル提供側の障害かを切り分けやすくなります。

## 確認内容
- `pnpm --filter ai test`
- `pnpm --filter ai typecheck`
- `pnpm -r test`
- `pnpm -r typecheck`
- `pnpm lint`
- `pnpm format`