### PR TITLE
[codex] fix(bot): AI サーバーエラー時に専用メッセージを返す

### DIFF
--- a/bot/__tests__/aiClient.test.ts
+++ b/bot/__tests__/aiClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "./setup.js";
 import { TestConstants } from "./setup.js";
-import { chatWithAi } from "../src/aiClient.js";
+import { chatWithAi, chatWithAiResult } from "../src/aiClient.js";
 
 const fetchMock = vi.fn();
 
@@ -58,6 +58,24 @@ describe("chatWithAi", () => {
   it("returns null on non-200 response", () => {
     fetchMock.mockReturnValue(fakeResponse(502, { error: "genai_failed" }));
     expect(chatWithAi("hi", "user:U123")).toBeNull();
+  });
+
+  it("returns server_error result on 5xx response", () => {
+    fetchMock.mockReturnValue(fakeResponse(502, { error: "genai_failed" }));
+    expect(chatWithAiResult("hi", "user:U123")).toEqual({
+      ok: false,
+      reason: "server_error",
+      status: 502,
+    });
+  });
+
+  it("returns client_error result on 4xx response", () => {
+    fetchMock.mockReturnValue(fakeResponse(400, { error: "invalid_request" }));
+    expect(chatWithAiResult("hi", "user:U123")).toEqual({
+      ok: false,
+      reason: "client_error",
+      status: 400,
+    });
   });
 
   it("returns null when reply is empty string", () => {

--- a/bot/__tests__/controller.test.ts
+++ b/bot/__tests__/controller.test.ts
@@ -1,11 +1,30 @@
 import { describe, expect, it, vi } from "vitest";
 import "./setup.js";
 import { generateReply } from "../src/controller.js";
+import type { AiClientResult } from "../src/aiClient.js";
 import type { LineSource } from "../src/types/line.js";
 
 const USER_SOURCE: LineSource = { type: "user", userId: "U123" };
 const GROUP_SOURCE: LineSource = { type: "group", groupId: "C456" };
 const INVALID_SOURCE: LineSource = { type: "user" }; // userId 欠落
+
+function aiReply(reply: string): AiClientResult {
+  return { ok: true, reply };
+}
+
+function aiFailure(
+  reason:
+    | "skipped"
+    | "fetch_failed"
+    | "server_error"
+    | "client_error"
+    | "invalid_response",
+  status?: number,
+): AiClientResult {
+  return status === undefined
+    ? { ok: false, reason }
+    : { ok: false, reason, status };
+}
 
 describe("generateReply", () => {
   it("join event returns greeting", () => {
@@ -64,7 +83,7 @@ describe("generateReply", () => {
   });
 
   it("user 1:1: passes user:{id} sessionKey to AI", () => {
-    const ai = vi.fn(() => "あかはね〜、今日も元気だよ〜！");
+    const ai = vi.fn(() => aiReply("あかはね〜、今日も元気だよ〜！"));
     const fallback = vi.fn(() => "(should not be called)");
     const reply = generateReply(
       {
@@ -81,7 +100,7 @@ describe("generateReply", () => {
   });
 
   it("group mention: passes group:{id} sessionKey to AI", () => {
-    const ai = vi.fn(() => "ぼくはね〜、グループでも元気〜！");
+    const ai = vi.fn(() => aiReply("ぼくはね〜、グループでも元気〜！"));
     const reply = generateReply(
       {
         eventType: "message",
@@ -113,7 +132,7 @@ describe("generateReply", () => {
   });
 
   it("custom sessionKeyBuilder is used when provided", () => {
-    const ai = vi.fn(() => "ok");
+    const ai = vi.fn(() => aiReply("ok"));
     const sessionKeyBuilder = vi.fn(() => "override:Z");
     generateReply(
       {
@@ -129,7 +148,7 @@ describe("generateReply", () => {
   });
 
   it("AI failure (null) → fallback is used (sessionKey path)", () => {
-    const ai = vi.fn(() => null);
+    const ai = vi.fn(() => aiFailure("fetch_failed"));
     const fallback = vi.fn(() => "random!");
     const reply = generateReply(
       {
@@ -146,8 +165,8 @@ describe("generateReply", () => {
     expect(reply).toBe("random!");
   });
 
-  it("AI returns empty string → fallback is used", () => {
-    const ai = vi.fn(() => "");
+  it("AI invalid response → fallback is used", () => {
+    const ai = vi.fn(() => aiFailure("invalid_response", 200));
     const fallback = vi.fn(() => "random!");
     const reply = generateReply(
       {
@@ -159,5 +178,25 @@ describe("generateReply", () => {
       { ai, fallback },
     );
     expect(reply).toBe("random!");
+  });
+
+  it("AI 5xx response → server error fallback is used", () => {
+    const ai = vi.fn(() => aiFailure("server_error", 502));
+    const fallback = vi.fn(() => "random!");
+    const serverErrorFallback = vi.fn(
+      () => "あかはお昼寝しちゃった…むにゃむにゃ",
+    );
+    const reply = generateReply(
+      {
+        eventType: "message",
+        userMessage: "なんか喋って",
+        isBotMentioned: true,
+        source: USER_SOURCE,
+      },
+      { ai, fallback, serverErrorFallback },
+    );
+    expect(reply).toBe("あかはお昼寝しちゃった…むにゃむにゃ");
+    expect(serverErrorFallback).toHaveBeenCalledOnce();
+    expect(fallback).not.toHaveBeenCalled();
   });
 });

--- a/bot/src/aiClient.ts
+++ b/bot/src/aiClient.ts
@@ -4,16 +4,34 @@ import type { components } from "./api/generated.js";
 type ChatRequest = components["schemas"]["ChatRequest"];
 type ChatResponse = components["schemas"]["ChatResponse"];
 
+export type AiClientFailureReason =
+  | "skipped"
+  | "fetch_failed"
+  | "server_error"
+  | "client_error"
+  | "invalid_response";
+
+export type AiClientResult =
+  | { ok: true; reply: string }
+  | { ok: false; reason: AiClientFailureReason; status?: number };
+
 /**
  * AKA-AI の /chat/genai を叩いて応答テキストを取得する。
  * - GAS の UrlFetchApp を使う（fetch は GAS にないため）
  * - Script Properties から API キーを取得し base64 化してリクエストに含める
  * - sessionKey は controller 側で `buildSessionKey` から得る (空文字 / null は controller が AI 呼出をスキップする想定)
- * - 失敗時は null を返す（呼び出し元でフォールバック）
+ * - 失敗時は reason / status 付きの失敗結果を返す（呼び出し元でフォールバック）
  */
-export function chatWithAi(prompt: string, sessionKey: string): string | null {
-  if (!prompt || prompt.trim().length === 0) return null;
-  if (!sessionKey || sessionKey.length === 0) return null;
+export function chatWithAiResult(
+  prompt: string,
+  sessionKey: string,
+): AiClientResult {
+  if (!prompt || prompt.trim().length === 0) {
+    return { ok: false, reason: "skipped" };
+  }
+  if (!sessionKey || sessionKey.length === 0) {
+    return { ok: false, reason: "skipped" };
+  }
 
   const url = `${getAiBaseUrl().replace(/\/$/, "")}/chat/genai`;
   const encryptedApiKey = Utilities.base64Encode(
@@ -37,7 +55,7 @@ export function chatWithAi(prompt: string, sessionKey: string): string | null {
     });
   } catch (err) {
     console.error("aiClient: UrlFetchApp.fetch failed", err);
-    return null;
+    return { ok: false, reason: "fetch_failed" };
   }
 
   const status = response.getResponseCode();
@@ -46,15 +64,27 @@ export function chatWithAi(prompt: string, sessionKey: string): string | null {
     console.warn(
       `aiClient: /chat/genai returned ${status} (body=${text.slice(0, 200)})`,
     );
-    return null;
+    return {
+      ok: false,
+      reason: status >= 500 ? "server_error" : "client_error",
+      status,
+    };
   }
 
   try {
     const parsed = JSON.parse(text) as ChatResponse;
     const reply = parsed.reply;
-    return typeof reply === "string" && reply.length > 0 ? reply : null;
+    return typeof reply === "string" && reply.length > 0
+      ? { ok: true, reply }
+      : { ok: false, reason: "invalid_response", status };
   } catch (err) {
     console.error("aiClient: failed to parse response", err);
-    return null;
+    return { ok: false, reason: "invalid_response", status };
   }
+}
+
+/** 既存呼び出し向けの互換 wrapper。失敗時は従来通り null。 */
+export function chatWithAi(prompt: string, sessionKey: string): string | null {
+  const result = chatWithAiResult(prompt, sessionKey);
+  return result.ok ? result.reply : null;
 }

--- a/bot/src/aka.ts
+++ b/bot/src/aka.ts
@@ -24,3 +24,8 @@ export function sayRandom(): string {
   const idx = Math.floor(Math.random() * randomMessageList.length);
   return randomMessageList[idx];
 }
+
+/** AI サーバが 5xx を返したときの専用フォールバック。 */
+export function sayAiServerError(): string {
+  return "あかはお昼寝しちゃった…むにゃむにゃ";
+}

--- a/bot/src/controller.ts
+++ b/bot/src/controller.ts
@@ -1,5 +1,5 @@
 import * as AKA from "./aka.js";
-import { chatWithAi } from "./aiClient.js";
+import { chatWithAiResult, type AiClientResult } from "./aiClient.js";
 import { buildSessionKey } from "./lib/sessionKey.js";
 import type { LineSource } from "./types/line.js";
 
@@ -14,9 +14,11 @@ export interface GenerateReplyInput {
 
 export interface GenerateReplyDeps {
   /** AKA-AI を叩いて応答を取得する関数。テストで差し替え可能。 */
-  ai?: (prompt: string, sessionKey: string) => string | null;
-  /** AI 呼び出し失敗時のフォールバック。 */
+  ai?: (prompt: string, sessionKey: string) => AiClientResult;
+  /** AI 呼び出し失敗時の通常フォールバック。 */
   fallback?: () => string;
+  /** AKA-AI が 5xx を返したときの専用フォールバック。 */
+  serverErrorFallback?: () => string;
   /** LINE source から sessionKey を組み立てる関数。テストで差し替え可能。 */
   sessionKeyBuilder?: (source: LineSource) => string | null;
 }
@@ -45,16 +47,18 @@ export function generateReply(
   if (selfIntro !== null) return selfIntro;
 
   // AI に投げる。失敗時はランダム応答にフォールバック
-  const ai = deps.ai ?? chatWithAi;
+  const ai = deps.ai ?? chatWithAiResult;
   const fallback = deps.fallback ?? AKA.sayRandom;
+  const serverErrorFallback = deps.serverErrorFallback ?? AKA.sayAiServerError;
   const buildKey = deps.sessionKeyBuilder ?? buildSessionKey;
 
   // sessionKey が取れないなら AI 呼び出しをスキップして fallback (Req 1.5)
   const sessionKey = buildKey(input.source);
   if (sessionKey === null) return fallback();
 
-  const aiReply = ai(input.userMessage, sessionKey);
-  if (aiReply !== null && aiReply.length > 0) return aiReply;
+  const aiResult = ai(input.userMessage, sessionKey);
+  if (aiResult.ok) return aiResult.reply;
+  if (aiResult.reason === "server_error") return serverErrorFallback();
   return fallback();
 }
 


### PR DESCRIPTION
## 概要
- AI client に失敗理由と HTTP status を保持する戻り値を追加しました。
- `/chat/genai` が 5xx を返したときは、専用のフォールバックメッセージを LINE に返します。
- 既存の `chatWithAi()` は互換 wrapper として残し、失敗時は従来通り `null` を返します。

## 背景
AKA-AI がサーバーエラーを返したとき、LINE Bot が沈黙したり無関係なランダム応答を返したりすると、ユーザーにも運用者にも状況が分かりにくくなります。5xx 専用メッセージにすることで、内部事情を出さずに一時的な不調を伝えられます。

## 確認内容
- `pnpm --filter bot test`
- `pnpm --filter bot typecheck`
- `pnpm -r test`
- `pnpm -r typecheck`
- `pnpm lint`
- `pnpm format`