### PR TITLE
[codex] feat(ai): Gemini モデルリストを順番に試す

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,7 @@ env:
   GCP_REGION: asia-northeast1
   SERVICE_NAME: aka-ai-api-service
   IMAGE: asia.gcr.io/aka-ai-api/aka-ai-api-service-image
-  GEMINI_MODEL: gemini-3.5-flash
-  GEMINI_FALLBACK_MODELS: gemini-2.5-flash
+  GEMINI_MODELS: gemini-3.5-flash,gemini-2.5-flash
   # Cloud Run コンテナが ADC として使うランタイム SA。
   # Firestore (`conversation` collection) への RW のため `roles/datastore.user`
   # を付与してある必要がある。詳細は docs/deploy-setup.md。
@@ -123,7 +122,7 @@ jobs:
             --region ${{ env.GCP_REGION }} \
             --service-account ${{ env.RUNTIME_SA }} \
             --allow-unauthenticated \
-            --set-env-vars NODE_ENV=production,GEMINI_MODEL=${{ env.GEMINI_MODEL }},GEMINI_FALLBACK_MODELS=${{ env.GEMINI_FALLBACK_MODELS }},GCP_PROJECT_ID=${{ env.GCP_PROJECT_ID }}
+            --set-env-vars "^|^NODE_ENV=production|GEMINI_MODELS=${{ env.GEMINI_MODELS }}|GCP_PROJECT_ID=${{ env.GCP_PROJECT_ID }}"
 
       - name: Smoke test (/health)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ env:
   SERVICE_NAME: aka-ai-api-service
   IMAGE: asia.gcr.io/aka-ai-api/aka-ai-api-service-image
   GEMINI_MODEL: gemini-3.5-flash
+  GEMINI_FALLBACK_MODELS: gemini-2.5-flash
   # Cloud Run コンテナが ADC として使うランタイム SA。
   # Firestore (`conversation` collection) への RW のため `roles/datastore.user`
   # を付与してある必要がある。詳細は docs/deploy-setup.md。
@@ -122,7 +123,7 @@ jobs:
             --region ${{ env.GCP_REGION }} \
             --service-account ${{ env.RUNTIME_SA }} \
             --allow-unauthenticated \
-            --set-env-vars NODE_ENV=production,GEMINI_MODEL=${{ env.GEMINI_MODEL }},GCP_PROJECT_ID=${{ env.GCP_PROJECT_ID }}
+            --set-env-vars NODE_ENV=production,GEMINI_MODEL=${{ env.GEMINI_MODEL }},GEMINI_FALLBACK_MODELS=${{ env.GEMINI_FALLBACK_MODELS }},GCP_PROJECT_ID=${{ env.GCP_PROJECT_ID }}
 
       - name: Smoke test (/health)
         run: |

--- a/ai/.env.sample
+++ b/ai/.env.sample
@@ -16,6 +16,10 @@ FIRESTORE_DATABASE_ID=(default)
 # 利用する Gemini モデル。env.ts のデフォルトは gemini-3.5-flash。
 GEMINI_MODEL=gemini-3.5-flash
 
+# primary モデルが 429/5xx/ネットワーク系で失敗したときに順番に試す fallback モデル。
+# カンマ区切り。未指定なら fallback なし。
+GEMINI_FALLBACK_MODELS=gemini-2.5-flash
+
 # pino のログレベル。fatal/error/warn/info/debug/trace/silent。
 LOG_LEVEL=debug
 

--- a/ai/.env.sample
+++ b/ai/.env.sample
@@ -13,12 +13,9 @@ GCP_PROJECT_ID=aka-ai-api
 # Firestore database id。複数 DB を使い分けないなら省略可。
 FIRESTORE_DATABASE_ID=(default)
 
-# 利用する Gemini モデル。env.ts のデフォルトは gemini-3.5-flash。
-GEMINI_MODEL=gemini-3.5-flash
-
-# primary モデルが 429/5xx/ネットワーク系で失敗したときに順番に試す fallback モデル。
-# カンマ区切り。未指定なら fallback なし。
-GEMINI_FALLBACK_MODELS=gemini-2.5-flash
+# 利用する Gemini モデル一覧。左から順番に試す。
+# 429/5xx/ネットワーク系の一過性失敗時のみ次のモデルへ進む。
+GEMINI_MODELS=gemini-3.5-flash,gemini-2.5-flash
 
 # pino のログレベル。fatal/error/warn/info/debug/trace/silent。
 LOG_LEVEL=debug

--- a/ai/__tests__/genai.test.ts
+++ b/ai/__tests__/genai.test.ts
@@ -63,8 +63,7 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
     PORT: 8080,
     LOG_LEVEL: "info",
-    GEMINI_MODEL: "gemini-test-model",
-    GEMINI_FALLBACK_MODELS: "",
+    GEMINI_MODELS: ["gemini-test-model"],
     NODE_ENV: "test",
     GCP_PROJECT_ID: "test-project",
     FIRESTORE_DATABASE_ID: "(default)",
@@ -295,7 +294,7 @@ describe("GenaiService.generate", () => {
     );
   });
 
-  it("retryable error の場合は fallback model を順番に試す", async () => {
+  it("retryable error の場合は GEMINI_MODELS を上から順番に試す", async () => {
     const { sendMessage, create } = await getMocks();
     sendMessage
       .mockRejectedValueOnce({ status: 503, message: "high demand" })
@@ -306,7 +305,7 @@ describe("GenaiService.generate", () => {
     const logger = makeLogger();
 
     const service = createGenaiService(
-      makeEnv({ GEMINI_FALLBACK_MODELS: "gemini-fallback-1" }),
+      makeEnv({ GEMINI_MODELS: ["gemini-test-model", "gemini-next-model"] }),
       logger,
     );
     const reply = await service.generate(makeInput());
@@ -317,7 +316,7 @@ describe("GenaiService.generate", () => {
       model: "gemini-test-model",
     });
     expect(create.mock.calls[1]?.[0]).toMatchObject({
-      model: "gemini-fallback-1",
+      model: "gemini-next-model",
     });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -331,7 +330,7 @@ describe("GenaiService.generate", () => {
     );
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: "gemini-fallback-1",
+        model: "gemini-next-model",
         attempt: 2,
         status: "success",
         fallbackUsed: true,
@@ -340,12 +339,12 @@ describe("GenaiService.generate", () => {
     );
   });
 
-  it("non-retryable error の場合は fallback model を試さない", async () => {
+  it("non-retryable error の場合は後続 model を試さない", async () => {
     const { sendMessage, create } = await getMocks();
     sendMessage.mockRejectedValueOnce({ status: 400, message: "bad request" });
 
     const service = createGenaiService(
-      makeEnv({ GEMINI_FALLBACK_MODELS: "gemini-fallback-1" }),
+      makeEnv({ GEMINI_MODELS: ["gemini-test-model", "gemini-next-model"] }),
     );
 
     await expect(service.generate(makeInput())).rejects.toBeInstanceOf(
@@ -357,7 +356,7 @@ describe("GenaiService.generate", () => {
     });
   });
 
-  it("SAFETY ブロックの場合は fallback model を試さない", async () => {
+  it("SAFETY ブロックの場合は後続 model を試さない", async () => {
     const { sendMessage, create } = await getMocks();
     sendMessage.mockResolvedValueOnce({
       text: "",
@@ -365,7 +364,7 @@ describe("GenaiService.generate", () => {
     });
 
     const service = createGenaiService(
-      makeEnv({ GEMINI_FALLBACK_MODELS: "gemini-fallback-1" }),
+      makeEnv({ GEMINI_MODELS: ["gemini-test-model", "gemini-next-model"] }),
     );
 
     await expect(service.generate(makeInput())).rejects.toBeInstanceOf(

--- a/ai/__tests__/genai.test.ts
+++ b/ai/__tests__/genai.test.ts
@@ -64,6 +64,7 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     PORT: 8080,
     LOG_LEVEL: "info",
     GEMINI_MODEL: "gemini-test-model",
+    GEMINI_FALLBACK_MODELS: "",
     NODE_ENV: "test",
     GCP_PROJECT_ID: "test-project",
     FIRESTORE_DATABASE_ID: "(default)",
@@ -292,5 +293,84 @@ describe("GenaiService.generate", () => {
       }),
       "genai attempt failed",
     );
+  });
+
+  it("retryable error の場合は fallback model を順番に試す", async () => {
+    const { sendMessage, create } = await getMocks();
+    sendMessage
+      .mockRejectedValueOnce({ status: 503, message: "high demand" })
+      .mockResolvedValueOnce({
+        text: "fallback reply",
+        candidates: [{ finishReason: "STOP" }],
+      });
+    const logger = makeLogger();
+
+    const service = createGenaiService(
+      makeEnv({ GEMINI_FALLBACK_MODELS: "gemini-fallback-1" }),
+      logger,
+    );
+    const reply = await service.generate(makeInput());
+
+    expect(reply).toBe("fallback reply");
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0]?.[0]).toMatchObject({
+      model: "gemini-test-model",
+    });
+    expect(create.mock.calls[1]?.[0]).toMatchObject({
+      model: "gemini-fallback-1",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gemini-test-model",
+        attempt: 1,
+        status: "error",
+        fallbackUsed: false,
+        upstreamStatusCode: 503,
+      }),
+      "genai attempt failed",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gemini-fallback-1",
+        attempt: 2,
+        status: "success",
+        fallbackUsed: true,
+      }),
+      "genai attempt completed",
+    );
+  });
+
+  it("non-retryable error の場合は fallback model を試さない", async () => {
+    const { sendMessage, create } = await getMocks();
+    sendMessage.mockRejectedValueOnce({ status: 400, message: "bad request" });
+
+    const service = createGenaiService(
+      makeEnv({ GEMINI_FALLBACK_MODELS: "gemini-fallback-1" }),
+    );
+
+    await expect(service.generate(makeInput())).rejects.toBeInstanceOf(
+      GenaiServiceError,
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0]?.[0]).toMatchObject({
+      model: "gemini-test-model",
+    });
+  });
+
+  it("SAFETY ブロックの場合は fallback model を試さない", async () => {
+    const { sendMessage, create } = await getMocks();
+    sendMessage.mockResolvedValueOnce({
+      text: "",
+      candidates: [{ finishReason: "SAFETY" }],
+    });
+
+    const service = createGenaiService(
+      makeEnv({ GEMINI_FALLBACK_MODELS: "gemini-fallback-1" }),
+    );
+
+    await expect(service.generate(makeInput())).rejects.toBeInstanceOf(
+      GenaiSafetyBlockedError,
+    );
+    expect(create).toHaveBeenCalledTimes(1);
   });
 });

--- a/ai/src/config/env.ts
+++ b/ai/src/config/env.ts
@@ -1,12 +1,23 @@
 import { z } from "zod";
 
+const commaSeparatedListSchema = z.preprocess(
+  (value) => {
+    if (Array.isArray(value)) return value;
+    if (typeof value !== "string") return value;
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  },
+  z.array(z.string().min(1)).min(1),
+);
+
 const envSchema = z.object({
   PORT: z.coerce.number().int().positive().default(8080),
   LOG_LEVEL: z
     .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
     .default("info"),
-  GEMINI_MODEL: z.string().min(1).default("gemini-3.5-flash"),
-  GEMINI_FALLBACK_MODELS: z.string().default(""),
+  GEMINI_MODELS: commaSeparatedListSchema.default(["gemini-3.5-flash"]),
   NODE_ENV: z
     .enum(["development", "production", "test"])
     .default("development"),

--- a/ai/src/config/env.ts
+++ b/ai/src/config/env.ts
@@ -6,6 +6,7 @@ const envSchema = z.object({
     .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
     .default("info"),
   GEMINI_MODEL: z.string().min(1).default("gemini-3.5-flash"),
+  GEMINI_FALLBACK_MODELS: z.string().default(""),
   NODE_ENV: z
     .enum(["development", "production", "test"])
     .default("development"),

--- a/ai/src/services/genai.ts
+++ b/ai/src/services/genai.ts
@@ -5,8 +5,8 @@
  *   でセッションを毎リクエスト生成し、`chat.sendMessage({ message: userText })` で応答取得
  * - `safetySettings` は 4 カテゴリ (HARASSMENT / HATE_SPEECH / SEXUALLY_EXPLICIT /
  *   DANGEROUS_CONTENT) を `BLOCK_MEDIUM_AND_ABOVE` で固定 (Req 4.2)
- * - `GEMINI_MODEL` を primary とし、`GEMINI_FALLBACK_MODELS` をカンマ区切りの
- *   fallback 候補として 429/5xx/ネットワーク系の一過性失敗時だけ順番に試す。
+ * - `GEMINI_MODELS` をカンマ区切りの候補一覧として、429/5xx/ネットワーク系の
+ *   一過性失敗時だけ先頭から順番に試す。
  * - SAFETY ブロック (`finishReason === SAFETY`)・空 candidates・空 text は
  *   `GenaiSafetyBlockedError` を投げる。route 層が捕捉して履歴に保存せず、
  *   中立メッセージを返す (Req 4.3)
@@ -129,12 +129,8 @@ function logAttempt(
 }
 
 function getModelCandidates(env: Env): string[] {
-  const models = [
-    env.GEMINI_MODEL,
-    ...env.GEMINI_FALLBACK_MODELS.split(","),
-  ].map((model) => model.trim());
   const seen = new Set<string>();
-  return models.filter((model) => {
+  return env.GEMINI_MODELS.filter((model) => {
     if (model.length === 0 || seen.has(model)) return false;
     seen.add(model);
     return true;

--- a/ai/src/services/genai.ts
+++ b/ai/src/services/genai.ts
@@ -5,6 +5,8 @@
  *   でセッションを毎リクエスト生成し、`chat.sendMessage({ message: userText })` で応答取得
  * - `safetySettings` は 4 カテゴリ (HARASSMENT / HATE_SPEECH / SEXUALLY_EXPLICIT /
  *   DANGEROUS_CONTENT) を `BLOCK_MEDIUM_AND_ABOVE` で固定 (Req 4.2)
+ * - `GEMINI_MODEL` を primary とし、`GEMINI_FALLBACK_MODELS` をカンマ区切りの
+ *   fallback 候補として 429/5xx/ネットワーク系の一過性失敗時だけ順番に試す。
  * - SAFETY ブロック (`finishReason === SAFETY`)・空 candidates・空 text は
  *   `GenaiSafetyBlockedError` を投げる。route 層が捕捉して履歴に保存せず、
  *   中立メッセージを返す (Req 4.3)
@@ -126,94 +128,150 @@ function logAttempt(
   }
 }
 
+function getModelCandidates(env: Env): string[] {
+  const models = [
+    env.GEMINI_MODEL,
+    ...env.GEMINI_FALLBACK_MODELS.split(","),
+  ].map((model) => model.trim());
+  const seen = new Set<string>();
+  return models.filter((model) => {
+    if (model.length === 0 || seen.has(model)) return false;
+    seen.add(model);
+    return true;
+  });
+}
+
+function isRetryableUpstreamFailure(statusCode: number | undefined): boolean {
+  if (statusCode === undefined) return true;
+  return [429, 500, 502, 503, 504].includes(statusCode);
+}
+
+async function generateWithModel(input: {
+  ai: GoogleGenAI;
+  model: string;
+  history: ConversationMessage[];
+  userText: string;
+  attempt: number;
+  fallbackUsed: boolean;
+  logger?: Logger;
+}): Promise<string> {
+  const chat = input.ai.chats.create({
+    model: input.model,
+    config: {
+      systemInstruction: akaSystemInstruction,
+      safetySettings: SAFETY_SETTINGS,
+    },
+    history: input.history.map(toContent),
+  });
+
+  let response;
+  const startedAt = Date.now();
+  try {
+    response = await chat.sendMessage({ message: input.userText });
+  } catch (cause) {
+    // ApiKeyDecodeError は decodeApiKey からのみ伝播する想定だが念のため
+    if (cause instanceof ApiKeyDecodeError) throw cause;
+    logAttempt(input.logger, {
+      model: input.model,
+      attempt: input.attempt,
+      status: "error",
+      fallbackUsed: input.fallbackUsed,
+      durationMs: Date.now() - startedAt,
+      upstreamStatusCode: getErrorStatusCode(cause),
+    });
+    throw new GenaiServiceError("Failed to call Gemini", { cause });
+  }
+
+  // Req 4.3: SAFETY ブロック / 空 candidates / 空 text は SafetyBlockedError
+  const candidates = response.candidates ?? [];
+  const finishReason = candidates[0]?.finishReason;
+  if (finishReason === FinishReason.SAFETY) {
+    logAttempt(input.logger, {
+      model: input.model,
+      attempt: input.attempt,
+      status: "safety_blocked",
+      fallbackUsed: input.fallbackUsed,
+      durationMs: Date.now() - startedAt,
+      finishReason,
+    });
+    throw new GenaiSafetyBlockedError(
+      "Gemini blocked the response by safetySettings",
+    );
+  }
+  if (candidates.length === 0) {
+    logAttempt(input.logger, {
+      model: input.model,
+      attempt: input.attempt,
+      status: "safety_blocked",
+      fallbackUsed: input.fallbackUsed,
+      durationMs: Date.now() - startedAt,
+      finishReason,
+    });
+    throw new GenaiSafetyBlockedError(
+      "Gemini returned no candidates (treated as safety block)",
+    );
+  }
+
+  const reply = response.text;
+  if (!reply) {
+    logAttempt(input.logger, {
+      model: input.model,
+      attempt: input.attempt,
+      status: "safety_blocked",
+      fallbackUsed: input.fallbackUsed,
+      durationMs: Date.now() - startedAt,
+      finishReason,
+    });
+    throw new GenaiSafetyBlockedError(
+      "Gemini returned an empty response (treated as safety block)",
+    );
+  }
+  logAttempt(input.logger, {
+    model: input.model,
+    attempt: input.attempt,
+    status: "success",
+    fallbackUsed: input.fallbackUsed,
+    durationMs: Date.now() - startedAt,
+    finishReason,
+  });
+  return reply;
+}
+
 export function createGenaiService(env: Env, logger?: Logger): GenaiService {
   return {
     async generate({ history, userText, encryptedApiKey }) {
       // ApiKeyDecodeError はそのまま投げる (route 層が 400 invalid_api_key として直接処理)
       const apiKey = decodeApiKey(encryptedApiKey);
       const ai = new GoogleGenAI({ apiKey });
-      const model = env.GEMINI_MODEL;
+      const models = getModelCandidates(env);
+      let lastError: GenaiServiceError | undefined;
 
-      const chat = ai.chats.create({
-        model,
-        config: {
-          systemInstruction: akaSystemInstruction,
-          safetySettings: SAFETY_SETTINGS,
-        },
-        history: history.map(toContent),
-      });
+      for (const [index, model] of models.entries()) {
+        try {
+          return await generateWithModel({
+            ai,
+            model,
+            history,
+            userText,
+            attempt: index + 1,
+            fallbackUsed: index > 0,
+            logger,
+          });
+        } catch (err) {
+          if (err instanceof ApiKeyDecodeError) throw err;
+          if (err instanceof GenaiSafetyBlockedError) throw err;
+          if (!(err instanceof GenaiServiceError)) throw err;
 
-      let response;
-      const startedAt = Date.now();
-      try {
-        response = await chat.sendMessage({ message: userText });
-      } catch (cause) {
-        // ApiKeyDecodeError は decodeApiKey からのみ伝播する想定だが念のため
-        if (cause instanceof ApiKeyDecodeError) throw cause;
-        logAttempt(logger, {
-          model,
-          attempt: 1,
-          status: "error",
-          fallbackUsed: false,
-          durationMs: Date.now() - startedAt,
-          upstreamStatusCode: getErrorStatusCode(cause),
-        });
-        throw new GenaiServiceError("Failed to call Gemini", { cause });
+          lastError = err;
+          const statusCode = getErrorStatusCode(err.cause);
+          const isLastAttempt = index === models.length - 1;
+          if (isLastAttempt || !isRetryableUpstreamFailure(statusCode)) {
+            throw err;
+          }
+        }
       }
 
-      // Req 4.3: SAFETY ブロック / 空 candidates / 空 text は SafetyBlockedError
-      const candidates = response.candidates ?? [];
-      const finishReason = candidates[0]?.finishReason;
-      if (finishReason === FinishReason.SAFETY) {
-        logAttempt(logger, {
-          model,
-          attempt: 1,
-          status: "safety_blocked",
-          fallbackUsed: false,
-          durationMs: Date.now() - startedAt,
-          finishReason,
-        });
-        throw new GenaiSafetyBlockedError(
-          "Gemini blocked the response by safetySettings",
-        );
-      }
-      if (candidates.length === 0) {
-        logAttempt(logger, {
-          model,
-          attempt: 1,
-          status: "safety_blocked",
-          fallbackUsed: false,
-          durationMs: Date.now() - startedAt,
-          finishReason,
-        });
-        throw new GenaiSafetyBlockedError(
-          "Gemini returned no candidates (treated as safety block)",
-        );
-      }
-
-      const reply = response.text;
-      if (!reply) {
-        logAttempt(logger, {
-          model,
-          attempt: 1,
-          status: "safety_blocked",
-          fallbackUsed: false,
-          durationMs: Date.now() - startedAt,
-          finishReason,
-        });
-        throw new GenaiSafetyBlockedError(
-          "Gemini returned an empty response (treated as safety block)",
-        );
-      }
-      logAttempt(logger, {
-        model,
-        attempt: 1,
-        status: "success",
-        fallbackUsed: false,
-        durationMs: Date.now() - startedAt,
-        finishReason,
-      });
-      return reply;
+      throw lastError ?? new GenaiServiceError("No Gemini models configured");
     },
   };
 }


### PR DESCRIPTION
## 概要
- `GEMINI_MODELS` をカンマ区切りのモデル一覧として追加しました。
- 例: `GEMINI_MODELS=gemini-3.5-flash,gemini-2.5-flash`
- Gemini 呼び出しが `429`, `500`, `502`, `503`, `504`, または status 不明のネットワーク系エラーで失敗した場合だけ、一覧の次のモデルを上から順に試します。
- safety block や retry しても直らない 4xx / 設定ミス / 認証系の失敗では後続モデルを試しません。
- 本番デプロイでは `gemini-3.5-flash`, `gemini-2.5-flash` の順で設定します。
- `gcloud run deploy --set-env-vars` はカンマ区切り値と衝突するため、workflow 側では `^|^` の区切り指定を使います。

## 背景
今回の障害は先頭モデルの一過性 high demand が原因でした。モデル一覧を順序付きで持ち、retryable な上流エラー時だけ次のモデルへ進むことで、設定の見通しを保ちながら応答継続の可能性を上げます。

## 確認内容
- `pnpm --filter ai test`
- `pnpm --filter ai typecheck`
- `pnpm -r test`
- `pnpm -r typecheck`
- `pnpm lint`
- `pnpm format`